### PR TITLE
[Pop'n music Plugin] Song rank and medal updates incorrectly

### DIFF
--- a/popn@asphyxia/README.md
+++ b/popn@asphyxia/README.md
@@ -1,6 +1,6 @@
 # Pop'n Music
 
-Plugin Version: **v1.1.0**
+Plugin Version: **v1.1.1**
 
 ## Supported Versions
 - pop'n music 23 Eclale
@@ -8,6 +8,9 @@ Plugin Version: **v1.1.0**
 - pop'n music 25 peace
 
 ## Changelog
+#### 1.1.1
+Fix when updating player song rank and medal the new result always overwrite the old record, even the record result is better.
+
 #### 1.1.0
 Update phase data : All versions are on latest phase.
 

--- a/popn@asphyxia/handler/player.ts
+++ b/popn@asphyxia/handler/player.ts
@@ -266,7 +266,7 @@ export const writeMusic: EPR = async (req, data, send) => {
     };
   } else {
     scoresData.scores[key].score = Math.max(score, scoresData.scores[key].score);
-	  scoresData.scores[key].cnt = scoresData.scores[key].cnt + 1;
+    scoresData.scores[key].cnt = scoresData.scores[key].cnt + 1;
   }
 
   if (clear_type) {

--- a/popn@asphyxia/handler/player.ts
+++ b/popn@asphyxia/handler/player.ts
@@ -265,10 +265,8 @@ export const writeMusic: EPR = async (req, data, send) => {
       cnt: 1,
     };
   } else {
-    scoresData.scores[key] = {
-      score: Math.max(score, scoresData.scores[key].score),
-      cnt: scoresData.scores[key].cnt + 1,
-    };
+    scoresData.scores[key].score = Math.max(score, scoresData.scores[key].score);
+	  scoresData.scores[key].cnt = scoresData.scores[key].cnt + 1;
   }
 
   if (clear_type) {


### PR DESCRIPTION
Fix when updating player song rank and medal the new result always overwrite the old record, even the record result is better.