### PR TITLE
Fix TS2737 on SDVX plugin

### DIFF
--- a/sdvx@asphyxia/index.ts
+++ b/sdvx@asphyxia/index.ts
@@ -67,7 +67,7 @@ export function register() {
   MultiRoute('entry_e', true);
   MultiRoute('exception', true);
   R.Route('eventlog.write', (_, __, send) => send.object({
-    gamesession: K.ITEM('s64', 1n),
+    gamesession: K.ITEM('s64', BigInt(1)),
     logsendflg: K.ITEM('s32', 0),
     logerrlevel: K.ITEM('s32', 0),
     evtidnosendflg: K.ITEM('s32', 0)


### PR DESCRIPTION
TS2737: BigInt literals are not available when targeting lower than ES2020.