### PR TITLE
Persist secret music and rewards

### DIFF
--- a/gitadora@asphyxia/README.md
+++ b/gitadora@asphyxia/README.md
@@ -1,6 +1,6 @@
 GITADORA Plugin for Asphyxia-Core
 =================================
-![Version: v1.2.0](https://img.shields.io/badge/version-v1.2.0-blue)
+![Version: v1.2.1](https://img.shields.io/badge/version-v1.2.1-blue)
 
 This plugin is based on converted from public-exported Asphyxia's Routes.
 
@@ -23,12 +23,19 @@ The folder structure between v1.0 and v1.1 is quite different. Do not overwrite 
 
 Known Issues
 ============
- * Information dialog keep showing as plugin doesn't store item data currently.
+ * ~Information dialog keep showing as plugin doesn't store item data currently.~ (Fixed as of version 1.2.1)
  * Special Premium Encore on Nextage
    - Bandage solution is implemented. Try it.
 
 Release Notes
 =============
+
+v1.2.1
+----------------
+* Secret Music (unlocked songs) are now saved and loaded correctly. Partially fixes Github issue #34. Note that all songs are already marked as unlocked by the server - there is no need to unlock them manually. If you would like to lock them, consider using a custom MDB.
+* Rewards field is now saved and loaded correctly. Fixes Github issue #34
+
+NOTE: Rewards and secret music is saved at the end of each session, so you will see the unlock notifications one last time after updating the plugin to this version.
 
 v1.2.0
 ----------------

--- a/gitadora@asphyxia/models/profile.ts
+++ b/gitadora@asphyxia/models/profile.ts
@@ -1,3 +1,5 @@
+import { SecretMusicEntry } from "./secretmusicentry";
+
 export interface Profile {
   collection: 'profile';
 
@@ -54,4 +56,7 @@ export interface Profile {
   exce_music_num: number;
   clear_seq_num: number;
   classic_all_skill: number;
+  secretmusic: {
+    music: SecretMusicEntry[];    
+  }
 }

--- a/gitadora@asphyxia/models/secretmusicentry.ts
+++ b/gitadora@asphyxia/models/secretmusicentry.ts
@@ -1,0 +1,5 @@
+export interface SecretMusicEntry {
+    musicid: number;
+    seq: number;
+    kind: number;
+}


### PR DESCRIPTION
- Secret music (unlocked songs) are now saved and loaded correctly. Partially fixes issue https://github.com/asphyxia-core/plugins/issues/34.
- Rewards are now saved and loaded correctly. Partially fixes issue https://github.com/asphyxia-core/plugins/issues/34.

The above two fixes should prevent all unlock notifications from appearing more than once. NOTE: Rewards and secret music is saved at the end of each session, so you will see the unlock notifications one last time after updating the plugin to this version.