### PR TITLE
Fix loading MDB files in XML format

### DIFF
--- a/gitadora@asphyxia/README.md
+++ b/gitadora@asphyxia/README.md
@@ -1,6 +1,6 @@
 GITADORA Plugin for Asphyxia-Core
 =================================
-![Version: v1.2.2](https://img.shields.io/badge/version-v1.2.2-blue)
+![Version: v1.2.3](https://img.shields.io/badge/version-v1.2.3-blue)
 
 This plugin is based on converted from public-exported Asphyxia's Routes.
 
@@ -30,6 +30,10 @@ Known Issues
 
 Release Notes
 =============
+
+v1.2.3
+----------------
+ * Fixed bug preventing MDB files in XML format from loading (Thanks to DualEdge for reporting this ).
 
 v1.2.2
 ----------------

--- a/gitadora@asphyxia/data/mdb/index.ts
+++ b/gitadora@asphyxia/data/mdb/index.ts
@@ -17,7 +17,6 @@ type processRawDataHandler = (path: string) => Promise<CommonMusicData>
 const logger = new Logger("mdb")
 
 export async function readXML(path: string) {
-  logger.debugInfo(`Loading MDB data from ${path}.`)
   const xml = await IO.ReadFile(path, 'utf-8');
   const json = U.parseXML(xml, false)
   return json
@@ -40,7 +39,7 @@ export async function readMDBFile(path: string, processHandler?: processRawDataH
       result = JSON.parse(str)
     break;
     case '.xml':
-      processHandler ?? defaultProcessRawXmlData
+      processHandler = processHandler ?? defaultProcessRawXmlData
       result = await processHandler(path)
       // Uncomment to save the loaded XML file as JSON.
       // await IO.WriteFile(path.replace(".xml", ".json"), JSON.stringify(data))


### PR DESCRIPTION
Fixed bug preventing MDB files in XML format from loading correctly. Omnimix now works correctly again.