### PR TITLE
fix(sdvx): Use dynamic require instead of ESM style import

### DIFF
--- a/sdvx@asphyxia/README.md
+++ b/sdvx@asphyxia/README.md
@@ -1,6 +1,6 @@
 # SOUND VOLTEX
 
-Plugin Version: **v6.2.0**
+Plugin Version: **v6.2.1**
 
 ## Provide out of box usable exprience, everything is unlocked and good to go.  
 
@@ -32,6 +32,10 @@ This version save data is not compatible with some forks plugin, please use it w
 
 Change Log
 ===========
+
+## 6.2.1
+
+1. Fix asset loading error when plugin is initializing without node type installed.
 
 ## 6.2.0
 

--- a/sdvx@asphyxia/index.ts
+++ b/sdvx@asphyxia/index.ts
@@ -35,13 +35,12 @@ import { TRANSLATION_TABLE } from './utils';
 
 import { MusicRecord } from './models/music_record';
 
-import path from 'path';
-
 export let music_db;
 
 function load_music_db(){
 
   const fs = require('fs');
+  const path = require('path');
 
   if (U.GetConfig('sdvx_path') == '') {
     console.log('sdvx_path is not set, skipping music_db load');


### PR DESCRIPTION
Seems like users without @type/node installed couldn't use module import. Switching to require for workaround.