### PR TITLE
fix(sdvx/webui): Dynamic require for WebUI profiles rendering

### DIFF
--- a/sdvx@asphyxia/handlers/webui.ts
+++ b/sdvx@asphyxia/handlers/webui.ts
@@ -8,9 +8,9 @@ import { error } from 'console';
 import { unpackS3P } from '../s3p';
 import { music_db } from '..';
 import { zipFolderToFile } from '../utils/zip';
-import path from 'path';
 
 const joinUnder = (basePath: string, childPath: string) => {
+  const path = require('path');
   const sanitizedChild = (childPath ?? '').replace(/^[/\\]+/, '');
   return path.join(basePath, sanitizedChild);
 };
@@ -253,6 +253,7 @@ export const import_assets = async (data: { path: string }, send: WebUISend) => 
   const sdvxInstallPath = data.path;
   console.log(sdvxInstallPath)
   let fs = require('fs')
+  const path = require('path')
 
   const graphicsDir = path.join(sdvxInstallPath, 'data', 'graphics');
   if (!fs.existsSync(graphicsDir)) {


### PR DESCRIPTION
#78, but for the WebUI profile pages to correctly load game assets.

<img width="2175" height="1131" alt="image" src="https://github.com/user-attachments/assets/8280e37e-0ddd-47e6-bb0a-03e9397f7afe" />


The problematic imports are also present in https://github.com/asphyxia-core/plugins/blob/34b173ba4920d217d4995aaf51ff264fed5dad3f/sdvx%40asphyxia/s3p.ts#L2 & https://github.com/asphyxia-core/plugins/blob/34b173ba4920d217d4995aaf51ff264fed5dad3f/sdvx%40asphyxia/utils/zip.ts#L2 Not sure what these are used for, so leaving them untouched in this PR.