### PR TITLE
Fix gitadora galaxy wave playstyle length

### DIFF
--- a/gitadora@asphyxia/models/extra.ts
+++ b/gitadora@asphyxia/models/extra.ts
@@ -18,7 +18,7 @@ export interface Extra {
 }
 
 export function getDefaultExtra(game: 'gf' | 'dm', version: string, id: number) : Extra {
-  const playstyleLength = version == 'galaxywave' || version == 'galaxywave_delta' ? 70 : 50;
+  const playstyleLength = version == 'galaxywave_delta' ? 70 : 50;
   const result : Extra = {
     collection: 'extra',
     pluginVer: PLUGIN_VER,


### PR DESCRIPTION
The playstyle length was incorrectly set to 70, which didn't work for galaxy wave and the game rejected the card with "server is busy". This PR fixed the issue.
